### PR TITLE
allow multiple cluster to stream in the events, allow customise slack channel name and username

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Streams k8s events from k8s namespace to Slack channel as a Slack bot using inco
 Configuration is done via env variables that you set in deployment or configmap.
 
 * `K8S_EVENTS_STREAMER_INCOMING_WEB_HOOK_URL` - Slack web hook URL where to send events. Mandatory parameter.
+* `K8S_CLUSTER_NAME` - Allow multiple clusters to stream in the events.
+* `K8S_SLACK_CHANNEL` - Allow overwrite slack channel name.
+* `K8S_SLACK_USERNAME` - Allow overwrite slack username.
 * `K8S_EVENTS_STREAMER_NAMESPACE` - k8s namespace to collect events from. Will use be sending events from all namespaces if not specified
 * `K8S_EVENTS_STREAMER_DEBUG` - Enable debug print outs to the log. `False` if not defined. Set to `True` to enable.
 * `K8S_EVENTS_STREAMER_SKIP_DELETE_EVENTS` - Skip all events of type DELETED by setting  env variable to `True`. `False` if not defined. Very useful since those events tells you that k8s event was deleted which has no value to you as operator.

--- a/example-deployment.tf
+++ b/example-deployment.tf
@@ -88,6 +88,21 @@ resource "kubernetes_deployment" "streamer" {
           }
 
           env {
+            name  = "K8S_CLUSTER_NAME"
+            value = var.cluster_name
+          }
+
+          env {
+            name  = "K8S_SLACK_CHANNEL"
+            value = var.slack_channel
+          }
+
+          env {
+            name  = "K8S_SLACK_USERNAME"
+            value = var.slack_username
+          }
+
+          env {
             name  = "K8S_EVENTS_STREAMER_SKIP_DELETE_EVENTS"
             value = "True"
           }
@@ -103,5 +118,17 @@ resource "kubernetes_deployment" "streamer" {
 }
 
 variable "streamer_hook_url" {
+  type = string
+}
+
+variable "cluster_name" {
+  type = string
+}
+
+variable "slack_channel" {
+  type = string
+}
+
+variable "slack_username" {
   type = string
 }

--- a/example-deployment.yaml
+++ b/example-deployment.yaml
@@ -51,6 +51,15 @@ spec:
         env:
         - name: K8S_EVENTS_STREAMER_INCOMING_WEB_HOOK_URL
           value: PUT-WEB-HOOK-URL-HERE
+        # if you don't put anything, default to mycluster
+        - name: K8S_CLUSTER_NAME
+          value: PUT-CLUSTER-NAME-HERE
+        # if you don't put anything, default to #random
+        - name: K8S_SLACK_CHANNEL
+          value: PUT-SLACK-CHANNEL-HERE
+        # if you don't put anything, default to k8s-events-to-slack-streamer
+        - name: K8S_SLACK_USERNAME
+          value: PUT-SLACK-USERNAME-HERE
 #        - name: K8S_EVENTS_STREAMER_NAMESPACE
 #          value: 'default'
 #        - name: K8S_EVENTS_STREAMER_DEBUG

--- a/k8s-events-to-slack-streamer.py
+++ b/k8s-events-to-slack-streamer.py
@@ -11,7 +11,9 @@ import traceback
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
-
+slack_channel = os.environ.get('K8S_SLACK_CHANNEL', '#random')
+slack_username = os.environ.get('K8S_SLACK_USERNAME', 'k8s-events-to-slack-streamer')
+k8s_cluster_name = os.environ.get('K8S_CLUSTER_NAME', 'mycluster')
 
 def read_env_variable_or_die(env_var_name):
     value = os.environ.get(env_var_name, '')
@@ -50,9 +52,11 @@ def format_k8s_event_to_slack_message(event_object, notify=''):
         return obj.strftime('%d/%m/%Y %H:%M:%S %Z') if obj else "no info"
 
     message = {
+        'channel': slack_channel,
+        'username': slack_username,
         'attachments': [{
             'color': '#36a64f',
-            'title': event.message,
+            'title': 'Cluster: {}, {}'.format(k8s_cluster_name, event.message),
             'text': 'event type: {}, event reason: {}'.format(event_object['type'], event.reason),
             'footer': 'First time seen: {}, Last time seen: {}, Count: {}'.format(timestamp(event.first_timestamp),
                                                                                   timestamp(event.last_timestamp),


### PR DESCRIPTION
Hi,

First thing first, I really like your code which is very clean and lean compare to many other frameworks i saw.

* Here is the customisation i did for myself to stream in the events from multiple clusters. For each cluster deployment, user shall define K8S_CLUSTER_NAME, so in slack, we know which cluster it comes from.

* Since I don't create slack webhook per app (if you too, have too much slack apps), and simple cheap hack to allow overwrite K8S_SLACK_CHANNEL and K8S_SLACK_USERNAME.

* I put the variable on top of the program, so it is a global var for all new param, this will save few lines of the code from needing to pass it as function param. This is very opinionated. Feel free to comment, i can change it.

cheers,
Cheng Lim


